### PR TITLE
Change file open mode for GRID

### DIFF
--- a/Cities/DIOMIRA.py
+++ b/Cities/DIOMIRA.py
@@ -253,7 +253,7 @@ def DIOMIRA(argv):
         CLIB,CLEVEL))
 
     # open the input file 
-    with tables.open_file("{}/{}".format(PATH_IN,FILE_IN), "r+") as h5in: 
+    with tables.open_file("{}/{}".format(PATH_IN,FILE_IN), "r") as h5in: 
         # access the PMT raw data in file 
 
         pmtrd_ = h5in.root.pmtrd


### PR DESCRIPTION
We need to change the way to open the first HDF5 file. In other case we won't be able to run in the IFIC-GRID. There are errors like this:

IOError: file `/lustre/ific.uv.es/sw/ific/NEXT/Releases_ic/v1.0.0-alpha/icprod/data/nexus_NEW_NEXT_v0_08_00_Kr_ACTIVE_5bar_1000kev_0.next_10000.root.h5` exists but it can not be written

As we do not need to change the first file, we should open it in read mode. There is no problem writing files because they are created in the local filesystem of each node of the grid and they are copied later (when the job finished) using a special tool.

Changing from 'r+' to 'r' fixes the problem.
